### PR TITLE
Get rid of "found = in conditional" warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 fellowshipone-api-*.gem
 access_token.yml
 access_token_marshal.txt
+.bundle/*
+.idea/*

--- a/lib/readers/contribution_list_reader.rb
+++ b/lib/readers/contribution_list_reader.rb
@@ -21,7 +21,7 @@ module FellowshipOne
          options[:individual_id].nil? and 
          options[:start_date].nil? and 
          options[:end_date].nil? 
-        @url_data_path = '/giving/v1/contributionreceipts'
+          @url_data_path = '/giving/v1/contributionreceipts'
       end
             
       @url_data_params.merge!({:page => page}) if page


### PR DESCRIPTION
Given the latest fellowshipone-api gem being installed, I'm seeing the following warning some up:

``` ruby
/Users/jhagglund/.rvm/gems/ruby-1.9.3-p484@capacityassessor/gems/fellowshipone-api-0.6.0/lib/readers/contribution_list_reader.rb:24: warning: found = in conditional, should be ==
```

That is fixed by simply indenting the statement on line 24 so it's clear that it isn't part of the conditional. Simple fix, and I did test that this change clears up the warning.
